### PR TITLE
Add function to power the device down.

### DIFF
--- a/src/standby.rs
+++ b/src/standby.rs
@@ -26,6 +26,13 @@ impl<D: Device> StandbyMode<D> {
         }
     }
 
+    pub fn power_down(mut self) -> Result<D, (Self, D::Error)> {
+        match self.device.update_config(|config| config.set_pwr_up(false)) {
+            Ok(()) => Ok(self.device),
+            Err(e) => Err((self, e)),
+        }
+    }
+
     pub(crate) fn from_rx_tx(mut device: D) -> Self {
         device.ce_disable();
         StandbyMode { device }


### PR DESCRIPTION
Sometimes, it is handy to power the device down and force a reinitialization.

In my case, I completely remove power from the chip when it is not in use to conserve as much energy as possible.

Note that it might also be interesting to either have a split() method which returns the raw SPI/pin objects so that the SPI bus can be re-used for a different device on the same bus, or alternatively (as done by the epd_waveshare crate) a short-lived mutable reference to the SPI object could be passed to each individual function (or a separate wrapper type holding the reference could be introduced).