### PR TITLE
Asynchronous interface to send packets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,4 @@ edition = "2018"
 [dependencies]
 embedded-hal = "0.2.3"
 bitfield = "0.13.2"
+nb = "0.1.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,9 +66,9 @@ impl<E: Debug, CE: OutputPin<Error = E>, CSN: OutputPin<Error = E>, SPI: SpiTran
 
         // Reset value
         let mut config = Config(0b0000_1000);
-        config.set_mask_rx_dr(true);
-        config.set_mask_tx_ds(true);
-        config.set_mask_max_rt(true);
+        config.set_mask_rx_dr(false);
+        config.set_mask_tx_ds(false);
+        config.set_mask_max_rt(false);
         let mut device = NRF24L01 {
             ce,
             csn,


### PR DESCRIPTION
This pull request adds an asynchronous interface for sending. The new function returns an `nb::Result`.

Compared to the existing function, this interface has two advantages:
- It allows integration into user-defined interrupt handling, be it via "normal" interrupts or via userspace libraries such as gpio-cdev.
- It returns whether sending was successful (via the MAXRT flag), so that the caller can determine whether the receiver has sent an ACK.