### PR TITLE
Remove panicing behaviour from NRF24L01::new

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -7,6 +7,8 @@ use core::fmt::Debug;
 pub enum Error<SPIE: Debug> {
     /// Wrap an SPI error
     SpiError(SPIE),
+    /// Module not connected
+    NotConnected,
 }
 
 impl<SPIE: Debug> From<SPIE> for Error<SPIE> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,7 +90,12 @@ impl<E: Debug, CE: OutputPin<Error = E>, CSN: OutputPin<Error = E>, SPI: SpiTran
             spi,
             config,
         };
-        assert!(device.is_connected().unwrap());
+
+        match device.is_connected() {
+            Err(e) => return Err(e),
+            Ok(false) => return Err(Error::NotConnected),
+            _ => {}
+        }
 
         // TODO: activate features?
 


### PR DESCRIPTION
I think it would be better to return from new with an error instead of panicing. Especially since the case of not connected or broken module or wrong wiring can be discerned with some reliability.