### PR TITLE
use embedded_hal 1.0 SpiDevice, enable auto_ack and dynamic payload by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,6 @@ homepage = "https://github.com/astro/embedded-nrf24l01"
 edition = "2018"
 
 [dependencies]
-embedded-hal = "0.2.3"
+embedded-hal = "1"
 bitfield = "0.13.2"
 nb = "0.1.2"

--- a/src/config.rs
+++ b/src/config.rs
@@ -210,7 +210,9 @@ pub trait Configuration {
 
     /// Configure auto-acknowledgment for all RX pipes
     ///
-    /// TODO: handle switching tx/rx modes when auto-retransmit is enabled
+    /// Auto ack is handled by the nrf24 if:
+    /// 1. Auto ack feature is enabled on Feature Register
+    /// 2. Auto ack is enabled for the pipe the packet was received on
     fn set_auto_ack(
         &mut self,
         bools: &[bool; PIPES_COUNT],

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -70,6 +70,10 @@ impl<D: Device> TxMode<D> {
     ///
     /// This function behaves like `wait_empty()`, except that it returns whether sending was
     /// successful and that it provides an asynchronous interface.
+    ///
+    /// Automatic retransmission (set_auto_retransmit) and acks (set_auto_ack) have to be
+    /// enabled if you actually want to know if transmission was successful. 
+    /// Else the nrf24 just transmits the packet once and assumes it was received.
     pub fn poll_send(&mut self) -> nb::Result<bool, D::Error> {
         let (status, fifo_status) = self.device.read_register::<FifoStatus>()?;
         // We need to clear all the TX interrupts whenever we return Ok here so that the next call


### PR DESCRIPTION
Perhaps this could just be an embedded_hal 1.0 pull request since the upgrade is only a couple lines of change. But I also enabled some features by default because there's no way to do so from the config.rs public functions.

Let me know if you need some help documenting this crate, and/or refining the implementation. 

An example is sorely needed, instead of a slightly outdated config info on the README. So users know what code is supposed to work out of the box, I myself would've saved a lot of time debugging if there had been one.